### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/campus-project-board/build.gradle
+++ b/campus-project-board/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'mysql:mysql-connector-java:8.0.29'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 
     runtimeOnly 'com.h2database:h2'
 //    runtimeOnly 'com.mysql:mysql-connector-j'

--- a/campus-project-board/src/main/java/com/campus/projectboard/repository/ArticleCommentRepository.java
+++ b/campus-project-board/src/main/java/com/campus/projectboard/repository/ArticleCommentRepository.java
@@ -2,7 +2,9 @@ package com.campus.projectboard.repository;
 
 import com.campus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long>{
 
 }

--- a/campus-project-board/src/main/java/com/campus/projectboard/repository/ArticleRepository.java
+++ b/campus-project-board/src/main/java/com/campus/projectboard/repository/ArticleRepository.java
@@ -2,7 +2,9 @@ package com.campus.projectboard.repository;
 
 import com.campus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/campus-project-board/src/test/java/com/campus/projectboard/controller/DataRestTest.java
+++ b/campus-project-board/src/test/java/com/campus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,84 @@
+package com.campus.projectboard.controller;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Disabled("Spring Data REST 통합 테스트는 불필요하여 제외함")
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class DataRestTest {
+
+  private final MockMvc mvc;
+
+  DataRestTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName("[api] 게시글 리스트 조회")
+  @Test
+  void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/api/articles"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+
+  @DisplayName("[api] 게시글 단건 조회")
+  @Test
+  void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/api/articles/1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+
+  @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+  @Test
+  void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/api/articles/1/articleComments"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+
+  @DisplayName("[api] 댓글 리스트 조회")
+  @Test
+  void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/api/articleComments"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+
+  @DisplayName("[api] 댓글 단건 조회")
+  @Test
+  void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+    // Given
+
+    // When & Then
+    mvc.perform(get("/api/articleComments/1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+}


### PR DESCRIPTION
게시판, 게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, api 등의 존재 여부만 체크하게끔 통합테스트 작성

